### PR TITLE
fix: change substr() to substring()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,12 @@ const isDataOption = str => isMatchingOption(['--data ', '--data-ascii ', '-d ',
 const removeLeadingTrailingQuotes = (str) => {
   const quotes = ['\'', '"'];
   const newStr = str.trim();
-  return quotes.includes(newStr[0]) ? newStr.substr(1, newStr.length - 2) : newStr;
+  return quotes.includes(newStr[0]) ? newStr.substring(1, newStr.length - 2) : newStr;
 };
 
 const subStrFrom = (val, startFromVal) => {
   const dataPosition = val.indexOf(startFromVal);
-  return val.substr(dataPosition);
+  return val.substring(dataPosition);
 };
 
 const isJsonRequest = parsedCommand => (parsedCommand.headers[contentTypeHeader] &&
@@ -56,7 +56,7 @@ const parseQueryStrings = (url) => {
   const queryStrings = {};
   if (paramPosition !== -1) {
     // const splitUrl = parsedCommand.url.substr(0, paramPosition);
-    const paramsString = url.substr(paramPosition + 1);
+    const paramsString = url.substring(paramPosition + 1);
     const params = paramsString.split('&') || [];
 
     params.forEach((param) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,131 +1,149 @@
-const optionsRegex = /(--[a-zA-Z\-]+ '.*?')|(--[a-zA-Z\-]+)|(-[a-zA-Z\-]+? '.+?')|('?[a-z]+:\/\/.*?'+?)|("?[a-z]+:\/\/.*?"+?)/g; // eslint-disable-line
-const urlRegex = /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/; // eslint-disable-line
+const optionsRegex =
+  /(--[a-zA-Z\-]+ '.*?')|(--[a-zA-Z\-]+)|(-[a-zA-Z\-]+? '.+?')|('?[a-z]+:\/\/.*?'+?)|("?[a-z]+:\/\/.*?"+?)/g // eslint-disable-line
+const urlRegex =
+  /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/ // eslint-disable-line
 
-const contentTypeHeader = 'content-type';
-const jsonMimeType = 'application/json';
+const contentTypeHeader = 'content-type'
+const jsonMimeType = 'application/json'
 
 const isMatchingOption = (headers, str) => {
   for (let i = 0; i < headers.length; i += 1) {
     if (str.startsWith(headers[i])) {
-      return true;
+      return true
     }
   }
-  return false;
-};
+  return false
+}
 
-const isAHeaderOption = str => isMatchingOption(['-H ', '--headers '], str);
-const isDataOption = str => isMatchingOption(['--data ', '--data-ascii ', '-d ', '--data-raw ', '--data-urlencode ', '--data-binary '], str);
+const isAHeaderOption = str => isMatchingOption(['-H ', '--headers '], str)
+const isDataOption = str =>
+  isMatchingOption(
+    [
+      '--data ',
+      '--data-ascii ',
+      '-d ',
+      '--data-raw ',
+      '--data-urlencode ',
+      '--data-binary ',
+    ],
+    str,
+  )
 
-const removeLeadingTrailingQuotes = (str) => {
-  const quotes = ['\'', '"'];
-  const newStr = str.trim();
-  return quotes.includes(newStr[0]) ? newStr.substring(1, newStr.length - 2) : newStr;
-};
+const removeLeadingTrailingQuotes = str => {
+  const quotes = ["'", '"']
+  const newStr = str.trim()
+  return quotes.includes(newStr[0])
+    ? newStr.substring(1, newStr.length - 1)
+    : newStr
+}
 
 const subStrFrom = (val, startFromVal) => {
-  const dataPosition = val.indexOf(startFromVal);
-  return val.substring(dataPosition);
-};
+  const dataPosition = val.indexOf(startFromVal)
+  return val.substring(dataPosition)
+}
 
-const isJsonRequest = parsedCommand => (parsedCommand.headers[contentTypeHeader] &&
-  parsedCommand.headers[contentTypeHeader].indexOf(jsonMimeType) !== -1);
+const isJsonRequest = parsedCommand =>
+  parsedCommand.headers[contentTypeHeader] &&
+  parsedCommand.headers[contentTypeHeader].indexOf(jsonMimeType) !== -1
 
-const parseBodyByContentType = ({ body, headers }) => {
+const parseBodyByContentType = ({body, headers}) => {
   if (body && isJsonRequest(headers)) {
     try {
-      const cleanedBodyData = body.replace('\\"', '"').replace("\\'", "'");
-      return JSON.parse(cleanedBodyData);
+      const cleanedBodyData = body.replace('\\"', '"').replace("\\'", "'")
+      return JSON.parse(cleanedBodyData)
     } catch (ex) {
       // ignore json conversion error..
-      console.log('Cannot parse JSON Data ' + ex.message); // eslint-disable-line
+      console.log('Cannot parse JSON Data ' + ex.message) // eslint-disable-line
     }
   }
-  return body;
-};
+  return body
+}
 
-const parseOptionValue = (val) => {
-  const headerSplit = subStrFrom(val, ' ').split(':');
+const parseOptionValue = val => {
+  const headerSplit = subStrFrom(val, ' ').split(':')
   return {
     key: headerSplit[0].trim(),
     value: headerSplit[1].trim(),
-  };
-};
+  }
+}
 
-const parseQueryStrings = (url) => {
-  const paramPosition = url.indexOf('?');
-  const queryStrings = {};
+const parseQueryStrings = url => {
+  const paramPosition = url.indexOf('?')
+  const queryStrings = {}
   if (paramPosition !== -1) {
     // const splitUrl = parsedCommand.url.substr(0, paramPosition);
-    const paramsString = url.substring(paramPosition + 1);
-    const params = paramsString.split('&') || [];
+    const paramsString = url.substring(paramPosition + 1)
+    const params = paramsString.split('&') || []
 
-    params.forEach((param) => {
-          const splitParam = param.split('='); // eslint-disable-line
-          queryStrings[splitParam[0]] = splitParam[1]; // eslint-disable-line
-    });
+    params.forEach(param => {
+      const splitParam = param.split('=') // eslint-disable-line
+      queryStrings[splitParam[0]] = splitParam[1] // eslint-disable-line
+    })
   }
-  return queryStrings;
-};
+  return queryStrings
+}
 
-const parseUrlOption = (val) => {
-  const urlMatches = val.match(urlRegex) || [];
+const parseUrlOption = val => {
+  const urlMatches = val.match(urlRegex) || []
   if (urlMatches.length) {
-    const url = urlMatches[0]; // eslint-disable-line
+    const url = urlMatches[0] // eslint-disable-line
     return {
       url,
       queryStrings: parseQueryStrings(url),
-    };
+    }
   }
-  return { url: '', queryStrings: {} };
-};
+  return {url: '', queryStrings: {}}
+}
 
-const parseBody = val => removeLeadingTrailingQuotes(subStrFrom(val, ' '));
+const parseBody = val => removeLeadingTrailingQuotes(subStrFrom(val, ' '))
 
-const isACurlCommand = val => val.trim().startsWith('curl ');
-const isAUrlOption = (val) => {
-  const matches = val.match(urlRegex) || [];
-  return !!matches.length;
-};
+const isACurlCommand = val => val.trim().startsWith('curl ')
+const isAUrlOption = val => {
+  const matches = val.match(urlRegex) || []
+  return !!matches.length
+}
 
 /*
  * Parse cUrl command to a JSON structure
  * params:
  * command - cUrl command as a string.
  * return JSON object
-*/
+ */
 export function parse(command) {
-  if (!command) { return ''; }
+  if (!command) {
+    return ''
+  }
 
   const parsedCommand = {
     url: '',
-  };
+  }
 
   // quit if the command does not starts with curl
   if (isACurlCommand(command)) {
-    const matches = command.match(optionsRegex);
-    matches.forEach((val) => {
-      const option = removeLeadingTrailingQuotes(val);
+    const matches = command.match(optionsRegex)
+    matches.forEach(val => {
+      const option = removeLeadingTrailingQuotes(val)
       if (isAUrlOption(option)) {
-        const { url, queryStrings } = parseUrlOption(option);
-        parsedCommand.url = url;
-        parsedCommand.queryStrings = queryStrings;
+        const {url, queryStrings} = parseUrlOption(option)
+        parsedCommand.url = url
+        parsedCommand.queryStrings = queryStrings
       } else if (isAHeaderOption(option)) {
-        const { key, value } = parseOptionValue(option);
-        parsedCommand.headers = parsedCommand.headers || {};
-        parsedCommand.headers[key] = value;
+        const {key, value} = parseOptionValue(option)
+        parsedCommand.headers = parsedCommand.headers || {}
+        parsedCommand.headers[key] = value
       } else if (isDataOption(option)) {
-        parsedCommand.body = parseBody(option);
+        parsedCommand.body = parseBody(option)
       } else {
-        console.log(`Skipped Header ${val}`); // eslint-disable-line
+        console.log(`Skipped Header ${val}`) // eslint-disable-line
       }
-    }); // parse over matches ends
+    }) // parse over matches ends
 
     // should be checked after all the options are analyzed
     // so that we guarentee that we have content-type header
-    parsedCommand.body = parseBodyByContentType(parsedCommand);
+    parsedCommand.body = parseBodyByContentType(parsedCommand)
   }
 
-  return parsedCommand;
+  return parsedCommand
 }
 
-export default parse;
+export default parse


### PR DESCRIPTION
I've been reading your code, thank you for it! 😄

I noticed that it uses `substr()` which has been [deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr). 
I updated with `substring()` which should be an [adequate replacement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) if you agree. 

I didn't notice any ways set up to write tests in the repo, but I'd be happy to provide some if needed. 

This PR includes:
- changes to `src/index.js`.